### PR TITLE
fix(api): readiness-gate pool finalization for FedEx points ordering

### DIFF
--- a/api/src/pga-tournament-player/lib/pga-tournament-player.service.ts
+++ b/api/src/pga-tournament-player/lib/pga-tournament-player.service.ts
@@ -398,6 +398,8 @@ export class PgaTournamentPlayerService {
       return;
     }
 
+    let didCalculate = false;
+
     await repo.manager.transaction(async (txManager) => {
       const tournamentRepo = txManager.getRepository(PgaTournament);
       const tournamentPlayerRepo = txManager.getRepository(PgaTournamentPlayer);
@@ -450,7 +452,19 @@ export class PgaTournamentPlayerService {
       await tournamentRepo.update(tournament.id, {
         official_fedex_cup_points_calculated: true,
       });
+
+      didCalculate = true;
     });
+
+    // Emit after commit so handlers observe the persisted official points and
+    // the flipped `official_fedex_cup_points_calculated` flag. This is what
+    // retriggers readiness-gated pool finalization for FedEx-scored pools whose
+    // tournament reached COMPLETED before the official points landed.
+    if (didCalculate) {
+      this.eventBus.emit<PgaTournamentEventMap>('pga-tournament.official-points-calculated', {
+        pgaTournament,
+      });
+    }
   }
 
   private extractOfficialFedexCupPoints(

--- a/api/src/pga-tournament/lib/pga-tournament.events.ts
+++ b/api/src/pga-tournament/lib/pga-tournament.events.ts
@@ -11,7 +11,12 @@ export interface PgaTournamentScoresUpdatedPayload {
   pgaTournament: PgaTournament;
 }
 
+export interface PgaTournamentOfficialPointsCalculatedPayload {
+  pgaTournament: PgaTournament;
+}
+
 export type PgaTournamentEventMap = {
   'pga-tournament.status-updated': PgaTournamentStatusUpdatedPayload;
   'pga-tournament.scores-updated': PgaTournamentScoresUpdatedPayload;
+  'pga-tournament.official-points-calculated': PgaTournamentOfficialPointsCalculatedPayload;
 };

--- a/api/src/pool-tournament-user/lib/pool-tournament-user.service.ts
+++ b/api/src/pool-tournament-user/lib/pool-tournament-user.service.ts
@@ -1,4 +1,4 @@
-import { FindOptionsWhere, Repository } from 'typeorm';
+import { EntityManager, FindOptionsWhere, Repository } from 'typeorm';
 
 import { defaultListParams, IListParams, TypeOrmListService } from '../../common/api/list';
 import { PoolTournamentUserPick } from '../../pool-tournament-user-pick/lib/pool-tournament-user-pick.entity';
@@ -107,6 +107,60 @@ export class PoolTournamentUserService {
         repo
       );
     }
+  }
+
+  /**
+   * Recalculates tournament_score and fedex_cup_points for every
+   * pool_tournament_user in a pool tournament with a single set-based UPDATE
+   * that joins through picks → pool_tournament_player → pga_tournament_player.
+   *
+   * FedEx points resolve to the official points once the tournament has
+   * calculated them, otherwise the projected points. Emits nothing — callers
+   * decide whether a follow-up recompute/finalization event is warranted, which
+   * keeps this reusable inside a finalization transaction without self-racing.
+   *
+   * @param manager pass a transaction's EntityManager to run inside it;
+   *   defaults to the repository's manager for standalone calls.
+   * @returns the number of pool_tournament_user rows updated.
+   */
+  async recomputeScores(
+    poolTournamentId: string,
+    manager: EntityManager = this.poolTournamentUserRepo.manager
+  ): Promise<number> {
+    // Note: pool_tournament_user_pick has a typo in the FK column: "pool_tournamnet_user_id"
+    // Also note: pool_tournament_player FK to pga_tournament_player is column "pga_tournament_player" (not _id suffix)
+    const result = await manager.query(
+      `
+      UPDATE pool_tournament_user ptu
+      SET
+        tournament_score = sub.total_score,
+        fedex_cup_points = sub.total_fedex
+      FROM (
+        SELECT
+          ptup.pool_tournamnet_user_id AS user_id,
+          SUM(ptp.score_total)::int AS total_score,
+          COALESCE(SUM(
+            CASE
+              WHEN pgat.official_fedex_cup_points_calculated
+                THEN ptp.official_fedex_cup_points
+              ELSE ptp.projected_fedex_cup_points
+            END
+          ), 0) AS total_fedex
+        FROM pool_tournament_user_pick ptup
+        JOIN pool_tournament_player ptpl ON ptup.pool_tournament_player_id = ptpl.id
+        JOIN pga_tournament_player ptp ON ptpl.pga_tournament_player = ptp.id
+        JOIN pga_tournament pgat ON ptp.pga_tournament = pgat.id
+        WHERE ptup.pool_tournamnet_user_id IN (
+          SELECT id FROM pool_tournament_user WHERE pool_tournament_id = $1
+        )
+        GROUP BY ptup.pool_tournamnet_user_id
+      ) sub
+      WHERE ptu.id = sub.user_id
+      `,
+      [poolTournamentId]
+    );
+
+    return Array.isArray(result) ? (result[1] ?? 0) : 0;
   }
 
   private aggregateScore(picks: PoolTournamentUserPick[]): number | null {

--- a/api/src/pool-tournament/lib/pool-finalization-reaction.handler.integration.spec.ts
+++ b/api/src/pool-tournament/lib/pool-finalization-reaction.handler.integration.spec.ts
@@ -40,8 +40,10 @@ describe('PoolFinalizationReactionHandler (integration)', () => {
   });
 
   it('increments pool_user.pool_score by fedex_cup_points on COMPLETED', async () => {
+    // A FedEx pool is only ready to finalize once official points are calculated.
     const pgaTournament = await createPgaTournament(ds, {
       tournament_status: PgaTournamentStatus.COMPLETED,
+      official_fedex_cup_points_calculated: true,
     });
     const pool = await createPool(ds, {
       overrides: {
@@ -58,7 +60,12 @@ describe('PoolFinalizationReactionHandler (integration)', () => {
     const tp = await createPgaTournamentPlayer(ds, {
       pgaPlayer: player,
       pgaTournament,
-      overrides: { score_total: -10, projected_fedex_cup_points: 400 },
+      // Finalization recomputes from official points, so those drive the total.
+      overrides: {
+        score_total: -10,
+        projected_fedex_cup_points: 0,
+        official_fedex_cup_points: 400,
+      },
     });
     const ptp = await createPoolTournamentPlayer(ds, {
       pgaTournamentPlayer: tp,
@@ -94,6 +101,71 @@ describe('PoolFinalizationReactionHandler (integration)', () => {
 
     const updatedPt = await ds.getRepository(PoolTournament).findOneBy({ id: poolTournament.id });
     expect(updatedPt?.scores_are_official).toBe(true);
+  });
+
+  it('skips a FedEx pool at COMPLETED until official points are calculated', async () => {
+    // The failure case: COMPLETED before official points land. Finalizing here
+    // would bake in a transient zero and lock the standings.
+    const pgaTournament = await createPgaTournament(ds, {
+      tournament_status: PgaTournamentStatus.COMPLETED,
+      official_fedex_cup_points_calculated: false,
+    });
+    const pool = await createPool(ds, {
+      overrides: {
+        settings: { scoring_format: PoolScoringFormat.FedexCuptPoints },
+      },
+    });
+    const poolTournament = await createPoolTournament(ds, {
+      pool,
+      pgaTournament,
+      league: pool.league,
+    });
+
+    const player = await createPgaPlayer(ds);
+    const tp = await createPgaTournamentPlayer(ds, {
+      pgaPlayer: player,
+      pgaTournament,
+      // Projected has already collapsed to zero for the finished event.
+      overrides: {
+        score_total: -10,
+        projected_fedex_cup_points: 0,
+        official_fedex_cup_points: null,
+      },
+    });
+    const ptp = await createPoolTournamentPlayer(ds, {
+      pgaTournamentPlayer: tp,
+      poolTournament,
+      overrides: { tier: 1 },
+    });
+
+    const poolUser = await createPoolUser(ds, {
+      pool,
+      league: pool.league,
+      overrides: { pool_score: 50 },
+    });
+    const ptu = await createPoolTournamentUser(ds, {
+      poolTournament,
+      poolUser,
+      league: pool.league,
+      overrides: { fedex_cup_points: 0 },
+    });
+    await createPoolTournamentUserPick(ds, {
+      poolTournamentUser: ptu,
+      poolTournamentPlayer: ptp,
+    });
+
+    await handler.handle({
+      pgaTournament,
+      previousStatus: PgaTournamentStatus.IN_PROGRESS,
+      newStatus: PgaTournamentStatus.COMPLETED,
+    });
+
+    const updatedPoolUser = await ds.getRepository(PoolUser).findOneBy({ id: poolUser.id });
+    // Not ready → skipped without locking. No zero baked into the standings.
+    expect(updatedPoolUser?.pool_score).toBe(50);
+
+    const updatedPt = await ds.getRepository(PoolTournament).findOneBy({ id: poolTournament.id });
+    expect(updatedPt?.scores_are_official).toBe(false);
   });
 
   it('increments pool_user.pool_score by tournament_score for Strokes format', async () => {
@@ -245,6 +317,7 @@ describe('PoolFinalizationReactionHandler (integration)', () => {
   it('handles COALESCE for users with zero fedex_cup_points', async () => {
     const pgaTournament = await createPgaTournament(ds, {
       tournament_status: PgaTournamentStatus.COMPLETED,
+      official_fedex_cup_points_calculated: true,
     });
     const pool = await createPool(ds, {
       overrides: {
@@ -261,7 +334,7 @@ describe('PoolFinalizationReactionHandler (integration)', () => {
     const tp = await createPgaTournamentPlayer(ds, {
       pgaPlayer: player,
       pgaTournament,
-      overrides: { score_total: 5, projected_fedex_cup_points: 0 },
+      overrides: { score_total: 5, projected_fedex_cup_points: 0, official_fedex_cup_points: 0 },
     });
     const ptp = await createPoolTournamentPlayer(ds, {
       pgaTournamentPlayer: tp,

--- a/api/src/pool-tournament/lib/pool-finalization-reaction.handler.ts
+++ b/api/src/pool-tournament/lib/pool-finalization-reaction.handler.ts
@@ -1,91 +1,19 @@
-import { DataSource } from 'typeorm';
-
 import { OnDomainEvent } from '../../domain-events/domain-event.decorator';
 import { DomainEventHandler } from '../../domain-events/domain-event.interface';
 import type { PgaTournamentStatusUpdatedPayload } from '../../pga-tournament/lib/pga-tournament.events';
 import { PgaTournamentStatus } from '../../pga-tournament/lib/pga-tournament.interface';
-import { PoolScoringFormat } from '../../pool/lib/pool.interface';
 
-import { PoolTournament } from './pool-tournament.entity';
-import { PoolTournamentService } from './pool-tournament.service';
-
-import { Logger, LoggerService, Optional } from '@nestjs/common';
+import { PoolFinalizationService } from './pool-finalization.service';
 
 @OnDomainEvent('pga-tournament.status-updated')
 export class PoolFinalizationReactionHandler implements DomainEventHandler<PgaTournamentStatusUpdatedPayload> {
-  constructor(
-    private readonly poolTournamentService: PoolTournamentService,
-    private readonly dataSource: DataSource,
-    @Optional()
-    private readonly logger: LoggerService = new Logger(PoolFinalizationReactionHandler.name)
-  ) {}
+  constructor(private readonly poolFinalizationService: PoolFinalizationService) {}
 
   async handle(payload: PgaTournamentStatusUpdatedPayload): Promise<void> {
     if (payload.newStatus !== PgaTournamentStatus.COMPLETED) {
       return;
     }
 
-    const poolTournaments = await this.poolTournamentService.listByPgaTournamentId(
-      payload.pgaTournament.id
-    );
-
-    for (const poolTournament of poolTournaments) {
-      if (poolTournament.scores_are_official) {
-        this.logger.log(
-          `Scores already official for pool tournament ${poolTournament.id}, skipping`
-        );
-        continue;
-      }
-
-      await this.finalizePoolTournament(poolTournament);
-    }
-  }
-
-  private async finalizePoolTournament(poolTournament: PoolTournament): Promise<void> {
-    const scoringFormat = poolTournament.pool?.settings?.scoring_format;
-    const scoreColumn = this.getScoreColumn(scoringFormat);
-
-    if (!scoreColumn) {
-      this.logger.warn(
-        `Unknown scoring format "${scoringFormat}" for pool tournament ${poolTournament.id}, skipping finalization`
-      );
-      return;
-    }
-
-    await this.dataSource.transaction(async (manager) => {
-      // Re-check within transaction
-      const pt = await manager.getRepository(PoolTournament).findOneBy({ id: poolTournament.id });
-      if (!pt || pt.scores_are_official) return;
-
-      // Update pool_user.pool_score += tournament score delta for each user
-      await manager.query(
-        `
-        UPDATE pool_user pu
-        SET pool_score = pu.pool_score + COALESCE(ptu.${scoreColumn}, 0)
-        FROM pool_tournament_user ptu
-        WHERE ptu.pool_user_id = pu.id
-          AND ptu.pool_tournament_id = $1
-        `,
-        [poolTournament.id]
-      );
-
-      // Mark as official
-      await manager.getRepository(PoolTournament).update(poolTournament.id, {
-        scores_are_official: true,
-      });
-
-      this.logger.log(`Finalized pool tournament ${poolTournament.id}`);
-    });
-  }
-
-  private getScoreColumn(scoringFormat: PoolScoringFormat | undefined): string | null {
-    switch (scoringFormat) {
-      case PoolScoringFormat.FedexCuptPoints:
-        return 'fedex_cup_points';
-      case PoolScoringFormat.Strokes:
-        return 'tournament_score';
-      default:
-        return null;
-    }
+    await this.poolFinalizationService.finalizeReadyPoolTournaments(payload.pgaTournament.id);
   }
 }

--- a/api/src/pool-tournament/lib/pool-finalization.integration.spec.ts
+++ b/api/src/pool-tournament/lib/pool-finalization.integration.spec.ts
@@ -1,0 +1,324 @@
+import { DataSource } from 'typeorm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createPgaPlayer,
+  createPgaTournament,
+  createPgaTournamentPlayer,
+  createPool,
+  createPoolTournament,
+  createPoolTournamentPlayer,
+  createPoolTournamentUser,
+  createPoolTournamentUserPick,
+  createPoolUser,
+} from '../../../test-helpers/factories';
+import { MockPgaTourApiService, setupTestApp } from '../../../test-helpers/setup-test-app';
+import { DomainEventBus } from '../../domain-events/domain-event-bus';
+import { PgaTourApiService } from '../../pga-tour-api/lib/v2/pga-tour-api.service';
+import { PgaTournament } from '../../pga-tournament/lib/pga-tournament.entity';
+import type { PgaTournamentEventMap } from '../../pga-tournament/lib/pga-tournament.events';
+import { PgaTournamentStatus } from '../../pga-tournament/lib/pga-tournament.interface';
+import { PgaTournamentPlayer } from '../../pga-tournament-player/lib/pga-tournament-player.entity';
+import { PgaTournamentPlayerService } from '../../pga-tournament-player/lib/pga-tournament-player.service';
+import { PoolScoringFormat } from '../../pool/lib/pool.interface';
+import { PoolTournamentUser } from '../../pool-tournament-user/lib/pool-tournament-user.entity';
+import { PoolUser } from '../../pool-user/lib/pool-user.entity';
+
+import { PoolFinalizationService } from './pool-finalization.service';
+import { PoolTournament } from './pool-tournament.entity';
+
+import { INestApplication } from '@nestjs/common';
+
+interface ScenarioOverrides {
+  scoringFormat?: PoolScoringFormat;
+  tournamentStatus?: PgaTournamentStatus;
+  officialCalculated?: boolean;
+  scoreTotal?: number | null;
+  projectedPoints?: number;
+  officialPoints?: number | null;
+}
+
+describe('Pool finalization (integration)', () => {
+  let app: INestApplication;
+  let ds: DataSource;
+  let finalizationService: PoolFinalizationService;
+  let eventBus: DomainEventBus;
+  let pgaTournamentPlayerService: PgaTournamentPlayerService;
+  let mockPgaTourApi: MockPgaTourApiService;
+
+  beforeAll(async () => {
+    const moduleRef = await setupTestApp().compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    ds = moduleRef.get(DataSource);
+    finalizationService = moduleRef.get(PoolFinalizationService);
+    eventBus = moduleRef.get(DomainEventBus);
+    pgaTournamentPlayerService = moduleRef.get(PgaTournamentPlayerService);
+    mockPgaTourApi = moduleRef.get(PgaTourApiService);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  /**
+   * Builds an isolated pool tournament with a single user picking a single
+   * player, so a finalize produces a deterministic pool_score delta.
+   */
+  async function createScenario(overrides: ScenarioOverrides = {}) {
+    const {
+      scoringFormat = PoolScoringFormat.FedexCuptPoints,
+      tournamentStatus = PgaTournamentStatus.COMPLETED,
+      officialCalculated = false,
+      scoreTotal = -8,
+      projectedPoints = 0,
+      officialPoints = 500,
+    } = overrides;
+
+    const pool = await createPool(ds, {
+      overrides: { settings: { scoring_format: scoringFormat } },
+    });
+    const pgaTournament = await createPgaTournament(ds, {
+      tournament_status: tournamentStatus,
+      official_fedex_cup_points_calculated: officialCalculated,
+    });
+    const poolTournament = await createPoolTournament(ds, {
+      pool,
+      pgaTournament,
+      league: pool.league,
+    });
+
+    const player = await createPgaPlayer(ds);
+    const tp = await createPgaTournamentPlayer(ds, {
+      pgaPlayer: player,
+      pgaTournament,
+      overrides: {
+        score_total: scoreTotal,
+        projected_fedex_cup_points: projectedPoints,
+        official_fedex_cup_points: officialPoints,
+      },
+    });
+    const ptp = await createPoolTournamentPlayer(ds, {
+      pgaTournamentPlayer: tp,
+      poolTournament,
+      overrides: { tier: 1 },
+    });
+
+    const poolUser = await createPoolUser(ds, { pool, league: pool.league });
+    const ptu = await createPoolTournamentUser(ds, {
+      poolTournament,
+      poolUser,
+      league: pool.league,
+    });
+    await createPoolTournamentUserPick(ds, {
+      poolTournamentUser: ptu,
+      poolTournamentPlayer: ptp,
+    });
+
+    return { pgaTournament, poolTournament, poolUser, poolTournamentUser: ptu, player };
+  }
+
+  const reloadPoolUser = (id: string) => ds.getRepository(PoolUser).findOneByOrFail({ id });
+  const reloadPoolTournament = (id: string) =>
+    ds.getRepository(PoolTournament).findOneByOrFail({ id });
+  const reloadPoolTournamentUser = (id: string) =>
+    ds.getRepository(PoolTournamentUser).findOneByOrFail({ id });
+
+  async function waitFor(
+    predicate: () => Promise<boolean>,
+    { timeoutMs = 3000, intervalMs = 25 } = {}
+  ) {
+    const start = Date.now();
+    for (;;) {
+      if (await predicate()) return;
+      if (Date.now() - start > timeoutMs) {
+        throw new Error('waitFor timed out');
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  it('skips a FedEx pool at COMPLETED before official points are calculated (no zero lock-in)', async () => {
+    const { pgaTournament, poolTournament, poolUser, poolTournamentUser } = await createScenario({
+      officialCalculated: false,
+    });
+
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+
+    expect((await reloadPoolTournament(poolTournament.id)).scores_are_official).toBe(false);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(0);
+    // Untouched: no recompute ran, so the transient projected zero is not baked in.
+    expect((await reloadPoolTournamentUser(poolTournamentUser.id)).fedex_cup_points).toBe(0);
+  });
+
+  it('finalizes a FedEx pool when official points arrive after COMPLETED, once', async () => {
+    const { pgaTournament, poolTournament, poolUser, poolTournamentUser } = await createScenario({
+      officialCalculated: false,
+    });
+
+    // status-updated arrives first: FedEx pool is not ready, so it is skipped.
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+    expect((await reloadPoolTournament(poolTournament.id)).scores_are_official).toBe(false);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(0);
+
+    // Official points land → flag flips → official-points-calculated retriggers.
+    await ds
+      .getRepository(PgaTournament)
+      .update(pgaTournament.id, { official_fedex_cup_points_calculated: true });
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+
+    expect((await reloadPoolTournament(poolTournament.id)).scores_are_official).toBe(true);
+    expect((await reloadPoolTournamentUser(poolTournamentUser.id)).fedex_cup_points).toBe(500);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(500);
+
+    // Re-firing does not double-count.
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(500);
+  });
+
+  it('finalizes a FedEx pool in one pass when official points are already calculated at COMPLETED', async () => {
+    const { pgaTournament, poolTournament, poolUser, poolTournamentUser } = await createScenario({
+      officialCalculated: true,
+    });
+
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+
+    expect((await reloadPoolTournament(poolTournament.id)).scores_are_official).toBe(true);
+    expect((await reloadPoolTournamentUser(poolTournamentUser.id)).fedex_cup_points).toBe(500);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(500);
+  });
+
+  it('is idempotent across repeated finalize calls', async () => {
+    const { pgaTournament, poolUser } = await createScenario({ officialCalculated: true });
+
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(500);
+  });
+
+  it('finalizes a strokes pool at COMPLETED regardless of FedEx official flag', async () => {
+    const { pgaTournament, poolTournament, poolUser, poolTournamentUser } = await createScenario({
+      scoringFormat: PoolScoringFormat.Strokes,
+      officialCalculated: false,
+      scoreTotal: -8,
+    });
+
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+
+    expect((await reloadPoolTournament(poolTournament.id)).scores_are_official).toBe(true);
+    expect((await reloadPoolTournamentUser(poolTournamentUser.id)).tournament_score).toBe(-8);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(-8);
+  });
+
+  it('does not finalize before the tournament reaches COMPLETED', async () => {
+    const { pgaTournament, poolTournament, poolUser } = await createScenario({
+      tournamentStatus: PgaTournamentStatus.IN_PROGRESS,
+      officialCalculated: true,
+    });
+
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+
+    expect((await reloadPoolTournament(poolTournament.id)).scores_are_official).toBe(false);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(0);
+  });
+
+  it('emits official-points-calculated from score ingestion, healing a finished FedEx pool end-to-end', async () => {
+    // COMPLETED FedEx tournament whose projected points already collapsed to 0
+    // and whose official points have not been calculated yet — the failure case.
+    const { pgaTournament, poolTournament, poolUser, poolTournamentUser, player } =
+      await createScenario({
+        officialCalculated: false,
+        projectedPoints: 0,
+        officialPoints: null,
+      });
+
+    // status-updated arrived first and (correctly) skipped this not-ready pool.
+    await finalizationService.finalizeReadyPoolTournaments(pgaTournament.id);
+    expect((await reloadPoolTournament(poolTournament.id)).scores_are_official).toBe(false);
+
+    // Field/score sync computes official points. Projected endpoint returns 0
+    // for the finished event; season results carry the real official points.
+    mockPgaTourApi.getTournamentLeaderboard.mockResolvedValue({
+      leaderboardId: pgaTournament.id,
+      leaderboard: {
+        timezone: 'America/New_York',
+        roundStatus: 'OFFICIAL',
+        tournamentStatus: 'COMPLETED',
+        formatType: 'STROKE_PLAY',
+        players: [
+          {
+            id: String(player.id).padStart(5, '0'),
+            player: {
+              firstName: 'Player',
+              lastName: String(player.id),
+              displayName: `Player ${player.id}`,
+            },
+            scoringData: {
+              playerState: 'COMPLETE',
+              total: '-8',
+              totalSort: -8,
+              thru: '18',
+              thruSort: 18,
+              position: '1',
+              score: '-8',
+              scoreSort: -8,
+              currentRound: 4,
+              teeTime: -1,
+              courseId: '1',
+              groupNumber: 1,
+              roundHeader: 'R4',
+              roundStatus: 'Complete',
+              totalStrokes: '272',
+              oddsToWin: '',
+            },
+          },
+        ],
+      },
+    });
+    mockPgaTourApi.getProjectedFedexCupPoints.mockResolvedValue({
+      seasonYear: pgaTournament.year,
+      lastUpdated: '',
+      points: [],
+    });
+    mockPgaTourApi.getPlayerSeasonResults.mockResolvedValue({
+      resultsData: [
+        {
+          title: 'FedExCup',
+          // index 10 carries the official FedEx Cup points value
+          data: [{ tournamentId: pgaTournament.id, fields: Array(10).fill('').concat('500') }],
+        },
+      ],
+    });
+
+    await pgaTournamentPlayerService.upsertFieldForTournament(pgaTournament.id);
+
+    // The official-points-calculated event fires fire-and-forget; wait for the
+    // finalization handler to mark the pool official.
+    await waitFor(async () => (await reloadPoolTournament(poolTournament.id)).scores_are_official);
+
+    expect(
+      (
+        await ds
+          .getRepository(PgaTournamentPlayer)
+          .findOneByOrFail({ id: `${player.id}-${pgaTournament.id}` })
+      ).official_fedex_cup_points
+    ).toBe(500);
+    expect((await reloadPoolTournamentUser(poolTournamentUser.id)).fedex_cup_points).toBe(500);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(500);
+  });
+
+  it('wires the official-points-calculated event to finalization', async () => {
+    const { pgaTournament, poolTournament, poolUser } = await createScenario({
+      officialCalculated: true,
+    });
+
+    eventBus.emit<PgaTournamentEventMap>('pga-tournament.official-points-calculated', {
+      pgaTournament,
+    });
+
+    await waitFor(async () => (await reloadPoolTournament(poolTournament.id)).scores_are_official);
+    expect((await reloadPoolUser(poolUser.id)).pool_score).toBe(500);
+  });
+});

--- a/api/src/pool-tournament/lib/pool-finalization.service.ts
+++ b/api/src/pool-tournament/lib/pool-finalization.service.ts
@@ -1,0 +1,132 @@
+import { DataSource } from 'typeorm';
+
+import { PgaTournamentStatus } from '../../pga-tournament/lib/pga-tournament.interface';
+import { PoolScoringFormat } from '../../pool/lib/pool.interface';
+import { PoolTournamentUserService } from '../../pool-tournament-user/lib/pool-tournament-user.service';
+
+import { PoolTournament } from './pool-tournament.entity';
+import { PoolTournamentService } from './pool-tournament.service';
+
+import { Injectable, Logger, LoggerService, Optional } from '@nestjs/common';
+
+/**
+ * Finalizes pool tournaments once their scoring inputs are actually final.
+ *
+ * Finalization is readiness-gated and order-independent: whichever of
+ * {tournament reaches COMPLETED, official FedEx points calculated} happens last
+ * drives the correct finalize. A pool tournament that is not yet ready is
+ * skipped WITHOUT locking, so a later `official-points-calculated` event can
+ * finalize it. Each finalize recomputes its own pool_tournament_user inputs, so
+ * it never bakes in a transient zero regardless of whether the scores-updated
+ * recompute has run.
+ */
+@Injectable()
+export class PoolFinalizationService {
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly poolTournamentService: PoolTournamentService,
+    private readonly poolTournamentUserService: PoolTournamentUserService,
+    @Optional()
+    private readonly logger: LoggerService = new Logger(PoolFinalizationService.name)
+  ) {}
+
+  async finalizeReadyPoolTournaments(pgaTournamentId: string): Promise<void> {
+    const poolTournaments = await this.poolTournamentService.listByPgaTournamentId(pgaTournamentId);
+
+    for (const poolTournament of poolTournaments) {
+      if (poolTournament.scores_are_official) {
+        this.logger.log(
+          `Scores already official for pool tournament ${poolTournament.id}, skipping`
+        );
+        continue;
+      }
+
+      if (!this.isReadyToFinalize(poolTournament)) {
+        this.logger.log(`Pool tournament ${poolTournament.id} not ready to finalize yet, skipping`);
+        continue;
+      }
+
+      await this.finalizePoolTournament(poolTournament);
+    }
+  }
+
+  /**
+   * A pool tournament is ready to finalize once its PGA tournament is COMPLETED
+   * and its scoring inputs are settled: strokes are settled at COMPLETED, while
+   * FedEx pools must additionally wait for official points to be calculated
+   * (the projected points collapse to zero for a finished event).
+   */
+  private isReadyToFinalize(poolTournament: PoolTournament): boolean {
+    if (poolTournament.pga_tournament?.tournament_status !== PgaTournamentStatus.COMPLETED) {
+      return false;
+    }
+
+    const scoringFormat = poolTournament.pool?.settings?.scoring_format;
+    switch (scoringFormat) {
+      case PoolScoringFormat.Strokes:
+        return true;
+      case PoolScoringFormat.FedexCuptPoints:
+        return poolTournament.pga_tournament.official_fedex_cup_points_calculated === true;
+      default:
+        return false;
+    }
+  }
+
+  private async finalizePoolTournament(poolTournament: PoolTournament): Promise<void> {
+    const scoringFormat = poolTournament.pool?.settings?.scoring_format;
+    const scoreColumn = this.getScoreColumn(scoringFormat);
+
+    if (!scoreColumn) {
+      this.logger.warn(
+        `Unknown scoring format "${scoringFormat}" for pool tournament ${poolTournament.id}, skipping finalization`
+      );
+      return;
+    }
+
+    await this.dataSource.transaction(async (manager) => {
+      // Serialize concurrent finalizes of the same pool tournament (e.g. the
+      // status-updated and official-points-calculated handlers overlapping).
+      // Shares the advisory-lock keyspace with the CLI finalizer.
+      await manager.query('SELECT pg_advisory_xact_lock(hashtext($1))', [poolTournament.id]);
+
+      // Re-check under the lock so a concurrent finalize can't double-count.
+      const pt = await manager.getRepository(PoolTournament).findOneBy({ id: poolTournament.id });
+      if (!pt || pt.scores_are_official) {
+        return;
+      }
+
+      // Recompute this pool tournament's user scores from the now-final inputs
+      // (no event emitted) so finalization never trusts a stale recompute.
+      await this.poolTournamentUserService.recomputeScores(poolTournament.id, manager);
+
+      // Add each user's tournament score into their running season pool_score.
+      await manager.query(
+        `
+        UPDATE pool_user pu
+        SET pool_score = pu.pool_score + COALESCE(ptu.${scoreColumn}, 0)
+        FROM pool_tournament_user ptu
+        WHERE ptu.pool_user_id = pu.id
+          AND ptu.pool_tournament_id = $1
+        `,
+        [poolTournament.id]
+      );
+
+      await manager.getRepository(PoolTournament).update(poolTournament.id, {
+        scores_are_official: true,
+      });
+
+      this.logger.log(`Finalized pool tournament ${poolTournament.id}`);
+    });
+  }
+
+  private getScoreColumn(scoringFormat: PoolScoringFormat | undefined): string | null {
+    switch (scoringFormat) {
+      case PoolScoringFormat.FedexCuptPoints:
+        return 'fedex_cup_points';
+      case PoolScoringFormat.Strokes:
+        return 'tournament_score';
+      default:
+        return null;
+    }
+  }
+}

--- a/api/src/pool-tournament/lib/pool-official-points-finalization-reaction.handler.ts
+++ b/api/src/pool-tournament/lib/pool-official-points-finalization-reaction.handler.ts
@@ -1,0 +1,20 @@
+import { OnDomainEvent } from '../../domain-events/domain-event.decorator';
+import { DomainEventHandler } from '../../domain-events/domain-event.interface';
+import type { PgaTournamentOfficialPointsCalculatedPayload } from '../../pga-tournament/lib/pga-tournament.events';
+
+import { PoolFinalizationService } from './pool-finalization.service';
+
+/**
+ * Retriggers finalization once official FedEx points land. This is the healing
+ * path for FedEx pools whose tournament reached COMPLETED before official
+ * points were calculated: the status-updated handler skipped them (not ready),
+ * and this event finalizes them with the correct values.
+ */
+@OnDomainEvent('pga-tournament.official-points-calculated')
+export class PoolOfficialPointsFinalizationReactionHandler implements DomainEventHandler<PgaTournamentOfficialPointsCalculatedPayload> {
+  constructor(private readonly poolFinalizationService: PoolFinalizationService) {}
+
+  async handle(payload: PgaTournamentOfficialPointsCalculatedPayload): Promise<void> {
+    await this.poolFinalizationService.finalizeReadyPoolTournaments(payload.pgaTournament.id);
+  }
+}

--- a/api/src/pool-tournament/lib/pool-score-reaction.handler.ts
+++ b/api/src/pool-tournament/lib/pool-score-reaction.handler.ts
@@ -1,8 +1,7 @@
-import { DataSource } from 'typeorm';
-
 import { OnDomainEvent } from '../../domain-events/domain-event.decorator';
 import { DomainEventHandler } from '../../domain-events/domain-event.interface';
 import type { PgaTournamentScoresUpdatedPayload } from '../../pga-tournament/lib/pga-tournament.events';
+import { PoolTournamentUserService } from '../../pool-tournament-user/lib/pool-tournament-user.service';
 
 import { PoolTournamentService } from './pool-tournament.service';
 
@@ -12,7 +11,7 @@ import { Logger, LoggerService, Optional } from '@nestjs/common';
 export class PoolScoreReactionHandler implements DomainEventHandler<PgaTournamentScoresUpdatedPayload> {
   constructor(
     private readonly poolTournamentService: PoolTournamentService,
-    private readonly dataSource: DataSource,
+    private readonly poolTournamentUserService: PoolTournamentUserService,
     @Optional()
     private readonly logger: LoggerService = new Logger(PoolScoreReactionHandler.name)
   ) {}
@@ -25,51 +24,10 @@ export class PoolScoreReactionHandler implements DomainEventHandler<PgaTournamen
     if (poolTournaments.length === 0) return;
 
     for (const poolTournament of poolTournaments) {
-      await this.updatePoolTournamentScores(poolTournament.id);
+      const affected = await this.poolTournamentUserService.recomputeScores(poolTournament.id);
+      this.logger.log(
+        `Updated scores for ${affected} pool user(s) in pool tournament ${poolTournament.id}`
+      );
     }
-  }
-
-  /**
-   * Single UPDATE query that recalculates tournament_score and fedex_cup_points
-   * for all pool_tournament_user records in a pool tournament by joining through
-   * picks → pool_tournament_player → pga_tournament_player.
-   */
-  private async updatePoolTournamentScores(poolTournamentId: string): Promise<void> {
-    // Note: pool_tournament_user_pick has a typo in the FK column: "pool_tournamnet_user_id"
-    // Also note: pool_tournament_player FK to pga_tournament_player is column "pga_tournament_player" (not _id suffix)
-    const result = await this.dataSource.query(
-      `
-      UPDATE pool_tournament_user ptu
-      SET
-        tournament_score = sub.total_score,
-        fedex_cup_points = sub.total_fedex
-      FROM (
-        SELECT
-          ptup.pool_tournamnet_user_id AS user_id,
-          SUM(ptp.score_total)::int AS total_score,
-          COALESCE(SUM(
-            CASE
-              WHEN pgat.official_fedex_cup_points_calculated
-                THEN ptp.official_fedex_cup_points
-              ELSE ptp.projected_fedex_cup_points
-            END
-          ), 0) AS total_fedex
-        FROM pool_tournament_user_pick ptup
-        JOIN pool_tournament_player ptpl ON ptup.pool_tournament_player_id = ptpl.id
-        JOIN pga_tournament_player ptp ON ptpl.pga_tournament_player = ptp.id
-        JOIN pga_tournament pgat ON ptp.pga_tournament = pgat.id
-        WHERE ptup.pool_tournamnet_user_id IN (
-          SELECT id FROM pool_tournament_user WHERE pool_tournament_id = $1
-        )
-        GROUP BY ptup.pool_tournamnet_user_id
-      ) sub
-      WHERE ptu.id = sub.user_id
-      `,
-      [poolTournamentId]
-    );
-
-    this.logger.log(
-      `Updated scores for ${result[1]} pool user(s) in pool tournament ${poolTournamentId}`
-    );
   }
 }

--- a/api/src/pool-tournament/lib/pool-tournament.module.ts
+++ b/api/src/pool-tournament/lib/pool-tournament.module.ts
@@ -2,7 +2,9 @@ import { ListModule } from '../../common/api/list';
 import { PgaTournamentPlayerModule } from '../../pga-tournament-player/lib/pga-tournament-player.module';
 import { PoolTournamentUserModule } from '../../pool-tournament-user/lib/pool-tournament-user.module';
 
+import { PoolFinalizationService } from './pool-finalization.service';
 import { PoolFinalizationReactionHandler } from './pool-finalization-reaction.handler';
+import { PoolOfficialPointsFinalizationReactionHandler } from './pool-official-points-finalization-reaction.handler';
 import { PoolScoreReactionHandler } from './pool-score-reaction.handler';
 import { PoolTournament } from './pool-tournament.entity';
 import { PoolTournamentService } from './pool-tournament.service';
@@ -21,8 +23,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
   providers: [
     PoolTournamentService,
     PoolTournamentFinalizerService,
+    PoolFinalizationService,
     PoolScoreReactionHandler,
     PoolFinalizationReactionHandler,
+    PoolOfficialPointsFinalizationReactionHandler,
   ],
   exports: [PoolTournamentService, PoolTournamentFinalizerService],
 })


### PR DESCRIPTION
## Problem

FedEx-Cup-scored pools could finish a tournament with every pool user showing `0`, and the season standings absorbed those zeros permanently (observed on the 2026 U.S. Open and 2026 Travelers, both recovered by hand).

Four async components act on a completing tournament without coordinating on when the FedEx scoring inputs are final:

1. The field sync refreshes projected points — and the PGA "projected" endpoint returns **0** for a finished event.
2. `status-updated → COMPLETED` fires and finalization runs while `official_fedex_cup_points_calculated` is still `false`, so the aggregate resolves to the projected branch = **0**, adds `0` to `pool_score`, and sets `scores_are_official = true` — **standings locked at zero**.
3. Official points land later but **emit no event**, so nothing recomputes.
4. The score-sync worker early-returns once status ≠ `IN_PROGRESS`, so the only recurring recompute source is silent exactly when official points arrive.

## Fix

Make finalization **readiness-gated**, **retriggered when official points arrive**, and **self-contained**. Order-independent: whichever of {status `COMPLETED`, official points calculated} happens last drives the correct finalize. No schema change.

- **D1** — Emit `pga-tournament.official-points-calculated` from `tryCalculateOfficialFedexCupPoints` after the writing transaction commits (only when work actually happened).
- **D2/D3** — New `PoolFinalizationService.finalizeReadyPoolTournaments()`: a pool tournament finalizes only when its PGA tournament is `COMPLETED` **and** (strokes | official FedEx points calculated). Not-ready pools are skipped **without locking**. Finalize recomputes its own `pool_tournament_user` inputs inside the transaction, so it never bakes in a stale zero. Both `PoolFinalizationReactionHandler` (status-updated) and the new `PoolOfficialPointsFinalizationReactionHandler` (official-points-calculated) delegate to it. Concurrency handled by the existing advisory lock + `scores_are_official` guard (idempotent).
- **Change 3** — Extract the `pool_tournament_user` recompute into `PoolTournamentUserService.recomputeScores(id, manager)`, shared by the scores-updated handler and the finalizer.

## Resulting behavior

- **Official points before `COMPLETED`:** `status-updated` finds the pool ready → finalizes correctly.
- **`COMPLETED` before official points (the failure case):** `status-updated` skips the FedEx pool (not ready, not locked); `official-points-calculated` then recomputes and finalizes it correctly.
- **Strokes pool:** finalizes at `COMPLETED` exactly as today.
- **Re-fired / duplicate events:** idempotent — no double-count.

## Testing

- `api/src/pool-tournament/lib/pool-finalization.integration.spec.ts` (new): both event orderings, idempotency, strokes, not-ready skip (no zero lock-in), pre-COMPLETED skip, event-bus wiring, and an **end-to-end heal** driving `upsertFieldForTournament` → official points → event → finalize.
- `pool-finalization-reaction.handler.integration.spec.ts`: updated to the readiness-gated behavior + a new handler-level skip test.

Full local verification: `api` lint clean, `build` ✓, unit tests (9) ✓, **integration tests (99) ✓**, app boots with all 3 domain-event handlers wired.

Out of scope (per plan): CLI `PoolTournamentFinalizerService` SERIALIZABLE self-race (D4); historical data backfill (handled by the manual SQL runbook).